### PR TITLE
Support `values` property in `MessageDescriptor`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,15 @@ To include components or elements in the middle of the message, use the provided
 
 ### MessageDescriptor Format
 
+When you need to interpolate dynamic values into the message, you can use the `values` property in the MessageDescriptor object:
+
+```svelte
+{$t({
+	message: 'Hello {name}',
+	values: { name: 'John' }
+})}
+```
+
 Sometimes we'll need to add a context info for messages that are exactly the same in the base language, but has different meanings in different places (e.g. in English `right` can either refer to direction or correctness). We can add a context by passing a message descriptor instead of plain string or literal string:
 
 ```svelte
@@ -237,7 +246,7 @@ Since Svelte's stores are meant to be used in Svelte components, using them insi
 ## Known issues
 
 - When extracting to Lingui's PO format and enabling the `origins` option, the line numbers are always empty for `<T>` components usage. The line numbers work on any other syntax.
-	- When working in a larger project in a team, I suggest disabling origins on the PO file anyway, since they cause a lot of line changes in diff view every time a string is added/reused. This might cause merge conflicts when two people are modifying or reusing the same string, for example.
+  - When working in a larger project in a team, I suggest disabling origins on the PO file anyway, since they cause a lot of line changes in diff view every time a string is added/reused. This might cause merge conflicts when two people are modifying or reusing the same string, for example.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -181,15 +181,6 @@ To include components or elements in the middle of the message, use the provided
 
 ### MessageDescriptor Format
 
-When you need to interpolate dynamic values into the message, you can use the `values` property in the MessageDescriptor object:
-
-```svelte
-{$t({
-	message: 'Hello {name}',
-	values: { name: 'John' }
-})}
-```
-
 Sometimes we'll need to add a context info for messages that are exactly the same in the base language, but has different meanings in different places (e.g. in English `right` can either refer to direction or correctness). We can add a context by passing a message descriptor instead of plain string or literal string:
 
 ```svelte
@@ -207,6 +198,15 @@ We can also add a comment for the translators reading the message catalog e.g. t
 {$t({
 	message: 'text',
 	context: 'message for translator'
+})}
+```
+
+Also, if you need to interpolate dynamic values into the message, you can use the `values` property in the MessageDescriptor object:
+
+```svelte
+{$t({
+	message: 'Hello {name}!',
+	values: { name: 'World' }
 })}
 ```
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Since Svelte's stores are meant to be used in Svelte components, using them insi
 ## Known issues
 
 - When extracting to Lingui's PO format and enabling the `origins` option, the line numbers are always empty for `<T>` components usage. The line numbers work on any other syntax.
-  - When working in a larger project in a team, I suggest disabling origins on the PO file anyway, since they cause a lot of line changes in diff view every time a string is added/reused. This might cause merge conflicts when two people are modifying or reusing the same string, for example.
+	- When working in a larger project in a team, I suggest disabling origins on the PO file anyway, since they cause a lot of line changes in diff view every time a string is added/reused. This might cause merge conflicts when two people are modifying or reusing the same string, for example.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-i18n-lingui",
-	"version": "0.2.1",
+	"version": "0.2.0",
 	"author": "Henry Roes Lie",
 	"license": "MIT",
 	"description": "Add i18n to Svelte/Sveltekit projects using Lingui, using message as the catalog id",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-i18n-lingui",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"author": "Henry Roes Lie",
 	"license": "MIT",
 	"description": "Add i18n to Svelte/Sveltekit projects using Lingui, using message as the catalog id",

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -4,7 +4,7 @@
  * @property {string} message - The message to be translated.
  * @property {string} [context] - The context of the message, will be included in the po file. The same message with different context will be extracted as separate entries, and can be translated differently.
  * @property {string} [comment] - A comment purely for giving information to the translator, won't affect translated string.
- * @property {Record<string, string>} [values] - An optional dictionary of values to be used in the message.
+ * @property {Record<string, any>} [values] - An optional dictionary of values to be used in the message.
  */
 
 import { writable, derived } from 'svelte/store';

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -4,6 +4,7 @@
  * @property {string} message - The message to be translated.
  * @property {string} [context] - The context of the message, will be included in the po file. The same message with different context will be extracted as separate entries, and can be translated differently.
  * @property {string} [comment] - A comment purely for giving information to the translator, won't affect translated string.
+ * @property {Record<string, string>} [values] - An optional dictionary of values to be used in the message.
  */
 
 import { writable, derived } from 'svelte/store';


### PR DESCRIPTION
The underlying Lingui functions accept the important additional property `MessageDescriptor.values` which makes the use of the `$t({ ... })` macro call (the one which takes an object as argument) a lot more useful.

This small change simply enhances the generated `*.d.ts` definition file to contain this property. Note that you can _already_ use this property even without this change; this only makes the IDE (e.g. VS Code) aware of it and adds a documentation paragraph about it.