### PR TITLE
fix: lingui expect Base64URL format since v6

### DIFF
--- a/src/lib/generateMessageId.js
+++ b/src/lib/generateMessageId.js
@@ -12,7 +12,7 @@ export function generateMessageId(msg, context = '') {
 	return hexToBase64(sha256(msg + UNIT_SEPARATOR + (context || ''))).slice(0, 6)
 		.replaceAll("/", "_")
 		.replaceAll("+", "-")
-		.replaceAll(/=+$/, "");
+		.replaceAll(/=+$/g, "");
 }
 
 /**

--- a/src/lib/generateMessageId.js
+++ b/src/lib/generateMessageId.js
@@ -9,7 +9,10 @@ const UNIT_SEPARATOR = '\u001F';
  * @param {string} msg
  */
 export function generateMessageId(msg, context = '') {
-	return hexToBase64(sha256(msg + UNIT_SEPARATOR + (context || ''))).slice(0, 6);
+	return hexToBase64(sha256(msg + UNIT_SEPARATOR + (context || ''))).slice(0, 6)
+		.replaceAll("/", "_")
+		.replaceAll("+", "-")
+		.replaceAll(/=+$/, "");
 }
 
 /**

--- a/src/lib/generateMessageId.js
+++ b/src/lib/generateMessageId.js
@@ -12,7 +12,7 @@ export function generateMessageId(msg, context = '') {
 	return hexToBase64(sha256(msg + UNIT_SEPARATOR + (context || ''))).slice(0, 6)
 		.replaceAll("/", "_")
 		.replaceAll("+", "-")
-		.replaceAll(/=+$/g, "");
+		.replace(/=+$/, "");
 }
 
 /**


### PR DESCRIPTION
Replace Base64 special characters with Base64URL to match [Message ID requirements in lingui v6](https://lingui.dev/releases/migration-6#message-id-generation-changed-to-url-safe-format)